### PR TITLE
Get and use temp federated user credentials.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ ext {
 }
 
 dependencies {
+    compile 'com.amazonaws:aws-java-sdk-sts:1.11.135'
     compile 'ro.ghionoiu:dev-screen-record:0.0.4'
     compile 'ro.ghionoiu:s3-sync-stream:0.0.8'
     compile 'com.beust:jcommander:1.64'

--- a/src/main/java/tdl/record_upload/RecordAndUploadScreen.java
+++ b/src/main/java/tdl/record_upload/RecordAndUploadScreen.java
@@ -6,19 +6,22 @@ import com.beust.jcommander.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
 import tdl.record.metrics.RecordingMetricsCollector;
+import tdl.record_upload.credentials.FederatedAuth;
 import tdl.record_upload.logging.LockableFileLoggingAppender;
 import tdl.s3.sync.progress.UploadStatsProgressListener;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Properties;
 
 @Slf4j
 public class RecordAndUploadScreen {
@@ -33,8 +36,11 @@ public class RecordAndUploadScreen {
         log.info("Starting recording app");
         RecordAndUploadScreen main = new RecordAndUploadScreen();
         new JCommander(main, args);
-
         try {
+            FederatedAuth federatedAuth = new FederatedAuth(main.configFile);
+            String tempCredentialsFileName = ".private/aws-temp-secrets";
+            federatedAuth.saveTempCredentials(tempCredentialsFileName);
+            main.configFile = tempCredentialsFileName;
             createMissingParentDirectories(main.localStorageFolder);
             removeOldLocks(main.localStorageFolder);
             startFileLogging(main.localStorageFolder);

--- a/src/main/java/tdl/record_upload/credentials/FederatedAuth.java
+++ b/src/main/java/tdl/record_upload/credentials/FederatedAuth.java
@@ -1,0 +1,46 @@
+package tdl.record_upload.credentials;
+
+import com.amazonaws.services.securitytoken.model.Credentials;
+
+import java.io.*;
+import java.util.Properties;
+
+public class FederatedAuth {
+
+    private final FederatedCredentialsProvider credentialsProvider;
+    private final String bucket;
+    private final String user;
+
+    public FederatedAuth(String propertiesFileName) throws IOException {
+        try (Reader reader = new FileReader(propertiesFileName)) {
+            Properties properties = new Properties();
+            properties.load(reader);
+            String awsAccessKeyId = properties.getProperty("aws_access_key_id");
+            String awsSecretAccessKey = properties.getProperty("aws_secret_access_key");
+
+            String s3Region = properties.getProperty("s3_region");
+            bucket = properties.getProperty("s3_bucket");
+            user = properties.getProperty("s3_prefix");
+            credentialsProvider = new FederatedCredentialsProvider(awsAccessKeyId, awsSecretAccessKey, s3Region, bucket);
+        }
+    }
+
+    public Properties getTempUserCredentials() {
+        Credentials credentials = credentialsProvider.getCredentials(user);
+        return new Properties(){{
+            put("aws_access_key_id", credentials.getAccessKeyId());
+            put("aws_secret_access_key", credentials.getSecretAccessKey());
+            put("aws_session_token", credentials.getSessionToken());
+            put("s3_region", "us-west-2");
+            put("s3_bucket", bucket);
+            put("s3_prefix", user + "/");
+        }};
+    }
+
+    public void saveTempCredentials(String fileName) throws IOException {
+        try (Writer writer = new FileWriter(fileName)) {
+            getTempUserCredentials().store(writer, "");
+        }
+    }
+
+}

--- a/src/main/java/tdl/record_upload/credentials/FederatedCredentialsProvider.java
+++ b/src/main/java/tdl/record_upload/credentials/FederatedCredentialsProvider.java
@@ -1,0 +1,68 @@
+package tdl.record_upload.credentials;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.policy.Condition;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import com.amazonaws.services.securitytoken.model.GetFederationTokenRequest;
+
+import java.util.Arrays;
+
+public class FederatedCredentialsProvider {
+
+    private final String s3Bucket;
+    private final AWSSecurityTokenService tokenService;
+
+    public FederatedCredentialsProvider(String accessKey, String secretKey, String region, String bucket) {
+        s3Bucket = bucket;
+
+        tokenService = AWSSecurityTokenServiceClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+                .build();
+    }
+
+    public Credentials getCredentials(String userNAme) {
+        GetFederationTokenRequest getFederationTokenRequest = new GetFederationTokenRequest()
+                .withName(userNAme)
+                .withPolicy(getPolicy(userNAme).toJson());
+        return tokenService.getFederationToken(getFederationTokenRequest).getCredentials();
+    }
+
+    private Policy getPolicy(String userName) {
+        Statement multipartUploadStatement = getMultipartUploadStatement(userName);
+        Statement creatingObjectsStatement = getObjectCreatingStatement(userName);
+
+        return new Policy("Files uploading policy", Arrays.asList(multipartUploadStatement, creatingObjectsStatement));
+    }
+
+    private Statement getObjectCreatingStatement(String userName) {
+        return new Statement(Statement.Effect.Allow)
+                .withActions(
+                        () -> "s3:PutObject",
+                        () -> "s3:GetObject"
+                )
+                .withResources(new Resource("arn:aws:s3:::" + s3Bucket + "/" + userName + "/*"));
+    }
+
+    private Statement getMultipartUploadStatement(String userName) {
+        return new Statement(Statement.Effect.Allow)
+                .withActions(
+                        () -> "s3:ListBucket",
+                        () -> "s3:ListBucketMultipartUploads"
+                )
+                .withResources(new Resource("arn:aws:s3:::" + s3Bucket))
+                .withConditions(
+                        new Condition()
+                                .withType("StringEquals")
+                                .withConditionKey("s3:prefix")
+                                .withValues(userName)
+                );
+    }
+}


### PR DESCRIPTION
I've added a class that retrieves temporal credentials. Now it's just proof of concept - it gets temporal credentials and saves them in a file, then the main app reads this file instead of original and uploads files with temp credentials. 
I've also tried it with AWS Lambda (separate project) and it works. Just not sure if create an artefact for Lambda there or it should be a separate project. 