### PR TITLE
Make project Java 9 compatible: first step of many steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ java -jar record-and-upload-VERSION-capsule.jar --config .private/aws-test-secre
 #### Java 9 versions
 
 ```bash
-java --illegal-access=warn --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED -jar record-and-upload-VERSION-capsule.jar --config .private/aws-test-secrets --store ./build/play
+java --illegal-access=warn  --add-modules=java.xml.bind,java.activation -jar record-and-upload-VERSION-capsule.jar --config .private/aws-test-secrets --store ./build/play
 ```
 
 
@@ -57,7 +57,7 @@ Ensure `JAVA_HOME` points to the Java 9 SDK home folder. Use `java -version` to 
 ```bash
 ./gradlew clean mavenCapsule
 rm -R ~/.capsule/deps/ro
-java --illegal-access=warn --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED -jar ./build/libs/record-and-upload-`cat version.txt`-capsule.jar --config .private/aws-test-secrets --store ./build/play
+java --illegal-access=warn  --add-modules=java.xml.bind,java.activation -jar ./build/libs/record-and-upload-`cat version.txt`-capsule.jar --config .private/aws-test-secrets --store ./build/play
 ```
 
 To generate test files you could run

--- a/README.md
+++ b/README.md
@@ -23,8 +23,16 @@ s3_prefix=prefix/
 
 ### Run
 
+#### pre-Java 9 versions
+
 ```bash
 java -jar record-and-upload-VERSION-capsule.jar --config .private/aws-test-secrets --store ./build/play
+```
+
+#### Java 9 versions
+
+```bash
+java --illegal-access=warn --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED -jar record-and-upload-VERSION-capsule.jar --config .private/aws-test-secrets --store ./build/play
 ```
 
 
@@ -33,10 +41,23 @@ java -jar record-and-upload-VERSION-capsule.jar --config .private/aws-test-secre
 ### Build and run as command-line app
 
 This will grate a maven based Jar that will download the required dependencies before running the app:
+
+#### Running and building with pre-Java 9 versions
+
 ```bash
 ./gradlew clean mavenCapsule
 rm -R ~/.capsule/deps/ro
 java -jar ./build/libs/record-and-upload-`cat version.txt`-capsule.jar --config .private/aws-test-secrets --store ./build/play
+```
+
+#### Running and building with Java 9
+
+Ensure `JAVA_HOME` points to the Java 9 SDK home folder. Use `java -version` to check if the java launcher on the `PATH` is version 9.0 (aka 1.9) or higher.
+
+```bash
+./gradlew clean mavenCapsule
+rm -R ~/.capsule/deps/ro
+java --illegal-access=warn --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED -jar ./build/libs/record-and-upload-`cat version.txt`-capsule.jar --config .private/aws-test-secrets --store ./build/play
 ```
 
 To generate test files you could run

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip


### PR DESCRIPTION
Upgraded gradle to 4.2.1 (more Java 9 compatible)  and updated the documentation on pre-Java 9 and Java 9 run command usages.

Can build and run using Java 9, although no Java 9 features like modules have been used yet. Just CLI switches to by pass the strict checks in Java 9.