### PR TITLE
Enable/disable Jansi from CLI

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,6 +2,20 @@
 
     <conversionRule conversionWord="color_by_level"
                     converterClass="tdl.record_upload.logging.ColorByLevelCompositeConverter" />
+    <!-- 
+        In Windows 10 (possibly future ones as well), using this feature along with logback or log4j can throw a harmless warning. 
+
+        See https://github.com/julianghionoiu/record-and-upload/issues/13 for more details.
+
+        Hence, passing -Dlogback.enableJansi=false from the command-line, disables the Jansi (console colouring) feature. 
+
+        For e.g.
+
+            java.exe -Dlogback.enableJansi="false" -jar [jarName] [other args...]
+
+        By default, Jansi is always be enabled (due to property set to true by default).
+    -->
+    <property name="ENABLE_JANSI_FLAG" value="${logback.enableJansi:-true}" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- On Windows machines setting withJansi to true enables ANSI
@@ -9,7 +23,7 @@
          org.fusesource.jansi:jansi:1.8 on the class path.  Note that
          Unix-based operating systems such as Linux and Mac OS X
          support ANSI color codes by default. -->
-        <withJansi>true</withJansi>
+        <withJansi>${ENABLE_JANSI_FLAG}</withJansi>
         <encoder>
             <pattern>%color_by_level(%-5level %-12([%thread])) - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
Make it possible to enable Jansi via a property which can be toggled from the command-line via the -D JVM option.

Happy to discuss if this is the right way to do it, or if there is a logback-idiomatic way of doing this.

Fixes https://github.com/julianghionoiu/record-and-upload/issues/13