### PR TITLE
Fix windows10 jansi issue - disable Jansi by default

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,15 +7,15 @@
 
         See https://github.com/julianghionoiu/record-and-upload/issues/13 for more details.
 
-        Hence, passing -Dlogback.enableJansi=false from the command-line, disables the Jansi (console colouring) feature. 
+        But by passing -Dlogback.enableJansi=true from the command-line, the Jansi (console colouring) feature can be. 
 
         For e.g.
 
-            java.exe -Dlogback.enableJansi="false" -jar [jarName] [other args...]
+            java.exe -Dlogback.enableJansi="true" -jar [jarName] [other args...]
 
-        By default, Jansi is always be enabled (due to property set to true by default).
+        By default, Jansi is always DISABLED (due to property set to "false").
     -->
-    <property name="ENABLE_JANSI_FLAG" value="${logback.enableJansi:-true}" />
+    <property name="ENABLE_JANSI_FLAG" value="${logback.enableJansi:-false}" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- On Windows machines setting withJansi to true enables ANSI

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,6 +2,20 @@
 
     <conversionRule conversionWord="color_by_level"
                     converterClass="tdl.record_upload.logging.ColorByLevelCompositeConverter" />
+    <!-- 
+        In Windows 10 (possibly future ones as well), using this feature along with logback or log4j can throw a harmless warning. 
+
+        See https://github.com/julianghionoiu/record-and-upload/issues/13 for more details.
+
+        Hence, passing -Dlogback.enableJansi=false from the command-line, disables the Jansi (console colouring) feature. 
+
+        For e.g.
+
+            java.exe -Dlogback.enableJansi="false" -jar [jarName] [other args...]
+
+        By default, Jansi is always be enabled (due to property set to true by default).
+    -->
+    <property name="ENABLE_JANSI_FLAG" value="${logback.enableJansi:-true}" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- On Windows machines setting withJansi to true enables ANSI
@@ -9,7 +23,7 @@
          org.fusesource.jansi:jansi:1.8 on the class path.  Note that
          Unix-based operating systems such as Linux and Mac OS X
          support ANSI color codes by default. -->
-        <withJansi>true</withJansi>
+        <withJansi>${ENABLE_JANSI_FLAG}</withJansi>
         <encoder>
             <pattern>%color_by_level(%-5level %-12([%thread])) - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
As per our discussion and agreement, lets disable this flag, but can be enabled via CLI if needed in the future, so the work is not totally lost and no new PR is needed to enable it